### PR TITLE
fix: detect linux architecture in install script

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -1,25 +1,34 @@
 #!/bin/sh
 
-set -e  # Exit on error
+set -e
 
-# Define the download URL
-URL="https://github.com/flowscripter/template-bun-executable/releases/latest/download/template-bun-executable_Linux_x86_64.zip"
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)
+    ARCH_SUFFIX="x64"
+    ;;
+  aarch64|arm64)
+    ARCH_SUFFIX="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
 
-# Create a temporary directory
+URL="https://github.com/flowscripter/template-bun-executable/releases/latest/download/template-bun-executable_Linux_${ARCH_SUFFIX}.zip"
+
 TMP_DIR=$(mktemp -d)
 cd "$TMP_DIR"
 
-# Download and extract
 echo "Downloading template-bun-executable..."
 curl -fsSL "$URL" -o executable.zip
 unzip executable.zip
 
-# Install
 chmod +x template-bun-executable
 sudo mv template-bun-executable /usr/local/bin/
 
-# Clean up
 cd -
 rm -rf "$TMP_DIR"
 
-echo "✅ Installation complete! Run 'template-bun-executable' to get started."
+echo "Installation complete! Run 'template-bun-executable' to get started."


### PR DESCRIPTION
## Summary

- Detects Linux architecture at runtime using `uname -m`
- Maps `x86_64` to `x64` and `aarch64`/`arm64` to `arm64`
- Exits with an error for unsupported architectures
- Fixes the hardcoded `x86_64` suffix that was wrong for both artifact naming and arm64 hosts

## Test plan

- [ ] Run on an x86_64 Linux host and verify it downloads `template-bun-executable_Linux_x64.zip`
- [ ] Run on an arm64 Linux host and verify it downloads `template-bun-executable_Linux_arm64.zip`
- [ ] Run on an unsupported arch and verify it exits with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)